### PR TITLE
Fix Kaniko builds' poor performance with local registry

### DIFF
--- a/bin/y-k3s-install
+++ b/bin/y-k3s-install
@@ -16,7 +16,13 @@ mirrors:
   "builds-registry.ystack.svc.cluster.local":
     endpoint:
     - http://builds-registry.ystack.svc.cluster.local
+  "builds-registry.ystack.svc.cluster.local:80":
+    endpoint:
+    - http://builds-registry.ystack.svc.cluster.local
   "prod-registry.ystack.svc.cluster.local":
+    endpoint:
+    - http://prod-registry.ystack.svc.cluster.local
+  "prod-registry.ystack.svc.cluster.local:80":
     endpoint:
     - http://prod-registry.ystack.svc.cluster.local
 EOF

--- a/examples/in-cluster-build/k8s/example-server-deployment.yaml
+++ b/examples/in-cluster-build/k8s/example-server-deployment.yaml
@@ -13,6 +13,6 @@ spec:
     spec:
       containers:
       - name: busybox
-        image: builds-registry.ystack.svc.cluster.local/ystack-examples/example-server
+        image: builds-registry.ystack.svc.cluster.local:80/ystack-examples/example-server
         ports:
         - containerPort: 8080

--- a/examples/in-cluster-build/skaffold.yaml
+++ b/examples/in-cluster-build/skaffold.yaml
@@ -3,6 +3,9 @@ kind: Config
 metadata:
   name: in-cluster-build
 build:
+  tagPolicy:
+    gitCommit:
+      variant: CommitSha
   artifacts:
   - image: builds-registry.ystack.svc.cluster.local/ystack-examples/example-server
     sync:

--- a/examples/in-cluster-build/skaffold.yaml
+++ b/examples/in-cluster-build/skaffold.yaml
@@ -7,7 +7,7 @@ build:
     gitCommit:
       variant: CommitSha
   artifacts:
-  - image: builds-registry.ystack.svc.cluster.local/ystack-examples/example-server
+  - image: builds-registry.ystack.svc.cluster.local:80/ystack-examples/example-server
     sync:
       infer: ["**/*"]
     kaniko:

--- a/k3s/image/registries.yaml
+++ b/k3s/image/registries.yaml
@@ -2,6 +2,12 @@ mirrors:
   "builds-registry.ystack.svc.cluster.local":
     endpoint:
     - http://builds-registry.ystack.svc.cluster.local
+  "builds-registry.ystack.svc.cluster.local:80":
+    endpoint:
+    - http://builds-registry.ystack.svc.cluster.local
   "prod-registry.ystack.svc.cluster.local":
+    endpoint:
+    - http://prod-registry.ystack.svc.cluster.local
+  "prod-registry.ystack.svc.cluster.local:80":
     endpoint:
     - http://prod-registry.ystack.svc.cluster.local


### PR DESCRIPTION
With this fix [kaniko](https://skaffold.dev/docs/pipeline-stages/builders/docker/#dockerfile-in-cluster-with-kaniko) build times are reduced significantly. `skaffold run` for the example goes from minutes to 10s of seconds.