### PR TITLE
Unique buildkit cache URLs per output image

### DIFF
--- a/bin/y-build
+++ b/bin/y-build
@@ -12,11 +12,6 @@ BUILDCTL_OPTS="$@"
 DEFAULT_REGISTRY=builds-registry.ystack.svc.cluster.local
 [ -z "$BUILDS_REGISTRY" ] && BUILDS_REGISTRY=$DEFAULT_REGISTRY
 [ -z "$PUSH_REGISTRY" ]   && PUSH_REGISTRY=$DEFAULT_REGISTRY
-[ -z "$BUILDKIT_CACHE" ]  && BUILDKIT_CACHE="type=registry,ref=$BUILDS_REGISTRY/ystack:buildcache"
-[ -z "$IMPORT_CACHE" ] && IMPORT_CACHE="--import-cache=$BUILDKIT_CACHE"
-[ -z "$EXPORT_CACHE" ] && EXPORT_CACHE="--export-cache=$BUILDKIT_CACHE,mode=max"
-[ "$IMPORT_CACHE" = "false" ] && IMPORT_CACHE=""
-[ "$EXPORT_CACHE" = "false" ] && EXPORT_CACHE=""
 [ -z "$BUILDKIT_HOST" ] && BUILDKIT_HOST=tcp://buildkitd.ystack.svc.cluster.local:8547
 
 if [ "$(curl -s --connect-timeout 3 http://$BUILDS_REGISTRY/v2/)" != "{}" ]
@@ -64,6 +59,12 @@ if [[ ! -z "$GIT_COMMIT" ]]; then
     GIT_COMMIT="$GIT_COMMIT-dirty"
   fi
 fi
+
+[ -z "$BUILDKIT_CACHE" ] && BUILDKIT_CACHE="type=registry,ref=$(echo $IMAGE | sed 's|/|/ystack-buildcache/|' | sed s/:$BUILD_TAG//)"
+[ -z "$IMPORT_CACHE" ] && IMPORT_CACHE="--import-cache=$BUILDKIT_CACHE"
+[ -z "$EXPORT_CACHE" ] && EXPORT_CACHE="--export-cache=$BUILDKIT_CACHE,mode=max"
+[ "$IMPORT_CACHE" = "false" ] && IMPORT_CACHE=""
+[ "$EXPORT_CACHE" = "false" ] && EXPORT_CACHE=""
 
 echo "Build command:"
 set -x

--- a/bin/y-build
+++ b/bin/y-build
@@ -60,7 +60,8 @@ if [[ ! -z "$GIT_COMMIT" ]]; then
   fi
 fi
 
-[ -z "$BUILDKIT_CACHE" ] && BUILDKIT_CACHE="type=registry,ref=$(echo $IMAGE | sed 's|/|/ystack-buildcache/|' | sed s/:$BUILD_TAG//)"
+REGISTRY_CACHE_DEFAULT=$(echo $IMAGE | sed "s|[^/]*|$BUILDS_REGISTRY/ystack-buildcache|" | sed "s/:$BUILD_TAG//")
+[ -z "$BUILDKIT_CACHE" ] && BUILDKIT_CACHE="type=registry,ref=$REGISTRY_CACHE_DEFAULT"
 [ -z "$IMPORT_CACHE" ] && IMPORT_CACHE="--import-cache=$BUILDKIT_CACHE"
 [ -z "$EXPORT_CACHE" ] && EXPORT_CACHE="--export-cache=$BUILDKIT_CACHE,mode=max"
 [ "$IMPORT_CACHE" = "false" ] && IMPORT_CACHE=""

--- a/bin/y-build
+++ b/bin/y-build
@@ -14,7 +14,7 @@ DEFAULT_REGISTRY=builds-registry.ystack.svc.cluster.local
 [ -z "$PUSH_REGISTRY" ]   && PUSH_REGISTRY=$DEFAULT_REGISTRY
 [ -z "$BUILDKIT_CACHE" ]  && BUILDKIT_CACHE="type=registry,ref=$BUILDS_REGISTRY/ystack:buildcache"
 [ -z "$IMPORT_CACHE" ] && IMPORT_CACHE="--import-cache=$BUILDKIT_CACHE"
-[ -z "$EXPORT_CACHE" ] && EXPORT_CACHE="--export-cache=$BUILDKIT_CACHE"
+[ -z "$EXPORT_CACHE" ] && EXPORT_CACHE="--export-cache=$BUILDKIT_CACHE,mode=max"
 [ "$IMPORT_CACHE" = "false" ] && IMPORT_CACHE=""
 [ "$EXPORT_CACHE" = "false" ] && EXPORT_CACHE=""
 [ -z "$BUILDKIT_HOST" ] && BUILDKIT_HOST=tcp://buildkitd.ystack.svc.cluster.local:8547


### PR DESCRIPTION
Let's test if this reduces our build times. Note that `,mode=max` would do so on its own.

To revert to a single build cache url run builds with `BUILDKIT_CACHE=builds-registry.ystack.svc.cluster.local/ystack:buildcache`.