### PR TITLE
WIP verify buildkit cache across builds and for any layer

### DIFF
--- a/examples/buildkit-cache/1.Dockerfile
+++ b/examples/buildkit-cache/1.Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209
+
+RUN echo "1 not cached!"

--- a/examples/buildkit-cache/2.Dockerfile
+++ b/examples/buildkit-cache/2.Dockerfile
@@ -1,0 +1,5 @@
+FROM busybox@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209
+
+RUN echo "1's cache not here!"
+
+RUN echo "2 not cached!"

--- a/examples/buildkit-cache/3.Dockerfile
+++ b/examples/buildkit-cache/3.Dockerfile
@@ -1,0 +1,3 @@
+FROM busybox@sha256:95cf004f559831017cdf4628aaf1bb30133677be8702a8c5f2994629f637a209
+
+RUN echo "3 not cached!"

--- a/examples/buildkit-cache/k8s/buildkit-cache-test-job.yaml
+++ b/examples/buildkit-cache/k8s/buildkit-cache-test-job.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: buildkit-cached-builds
+spec:
+  containers:
+  - name: build1
+    image: builds-registry.ystack.svc.cluster.local/ystack-examples/buildkit-cache-1
+  - name: build2
+    image: builds-registry.ystack.svc.cluster.local/ystack-examples/buildkit-cache-2
+  - name: build3
+    image: builds-registry.ystack.svc.cluster.local/ystack-examples/buildkit-cache-3
+  restartPolicy: Never

--- a/examples/buildkit-cache/skaffold.yaml
+++ b/examples/buildkit-cache/skaffold.yaml
@@ -1,0 +1,28 @@
+apiVersion: skaffold/v2beta5
+kind: Config
+metadata:
+  name: buildkit-cache
+build:
+  artifacts:
+  - image: builds-registry.ystack.svc.cluster.local/ystack-examples/buildkit-cache-1
+    custom:
+      buildCommand: y-build --opt filename=1.Dockerfile --progress=plain
+      dependencies:
+        dockerfile:
+          path: 1.Dockerfile
+  - image: builds-registry.ystack.svc.cluster.local/ystack-examples/buildkit-cache-2
+    custom:
+      buildCommand: y-build --opt filename=2.Dockerfile --progress=plain
+      dependencies:
+        dockerfile:
+          path: 2.Dockerfile
+  - image: builds-registry.ystack.svc.cluster.local/ystack-examples/buildkit-cache-3
+    custom:
+      buildCommand: y-build --opt filename=3.Dockerfile --progress=plain
+      dependencies:
+        dockerfile:
+          path: 3.Dockerfile
+deploy:
+  kubectl:
+    manifests:
+    - k8s/buildkit-cache-test-job.yaml


### PR DESCRIPTION
To be compared with y-build from before #31, i.e. 0885441. The easiest way to rerun (bar cleanup of build repo) is to sed the FROM. 