### PR TITLE
Lint and unit test shell scripts

### DIFF
--- a/bin/.gitignore
+++ b/bin/.gitignore
@@ -1,4 +1,5 @@
 *-bin
+*-dist
 
 # our executables are symlinked to real names
 buildctl
@@ -31,4 +32,6 @@ yq
 esbuild
 rpk
 remote-iap
+shellcheck
+shellspec
 zap-pretty

--- a/bin/.shellspec
+++ b/bin/.shellspec
@@ -1,0 +1,12 @@
+--require spec_helper
+
+## Default kcov (coverage) options
+# --kcov-options "--include-path=. --path-strip-level=1"
+# --kcov-options "--include-pattern=.sh"
+# --kcov-options "--exclude-pattern=/.shellspec,/spec/,/coverage/,/report/"
+
+## Example: Include script "myprog" with no extension
+# --kcov-options "--include-pattern=.sh,myprog"
+
+## Example: Only specified files/directories
+# --kcov-options "--include-pattern=myprog,/lib/"

--- a/bin/kubectl-waitretry
+++ b/bin/kubectl-waitretry
@@ -6,7 +6,7 @@ set -e
 
 SLEEP=1
 RETRY=0
-until kubectl wait $@; do
+until kubectl wait "$@"; do
   [ $RETRY -lt $WAITRETRIES ] || exit 1
   echo "waitretry after $SLEEP seconds ..."
   sleep $SLEEP

--- a/bin/spec/image-bump-example/preserve-sha256.yaml
+++ b/bin/spec/image-bump-example/preserve-sha256.yaml
@@ -1,0 +1,7 @@
+# when the sha256 is identical we should not change the URL
+# if there are no other replaced URLs in the file
+image00: yolean/toil:0000000000000000000000000000000000000000@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+and:
+  further:
+    down:
+      x: yolean/toil:1000000000000000000000000000000000000000@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d

--- a/bin/spec/image-bump-example/variations.yaml
+++ b/bin/spec/image-bump-example/variations.yaml
@@ -1,0 +1,16 @@
+image1: "yolean/toil:2804b31514bdf162fa3ac527cdb5b1b1cfd4d986"
+image2: yolean/toil:2804b31514bdf162fa3ac527cdb5b1b1cfd4d986
+# not git ref tagged, should be skipped
+image3: "yolean/toil"
+image4: yolean/toil
+image5: yolean/toil:123
+# should get a new tag+sha
+image6: yolean/toil:0000000000000000000000000000000000000000@sha256:0000000000000000000000000000000000000000000000000000000000000000
+# when other URLs change in this particular file we update instances of the same sha256 as well, see also preserve-sha256.yaml
+image7: yolean/toil:0000000000000000000000000000000000000000@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+# correct already, should not change
+image8: yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+# with host
+image9: "docker.io/yolean/toil:ac196cb3f08b15d2b8c6731533f9ab29a8629389@sha256:3c52b5ddac2c1da52eced6f727e530cef18ea9bd6ae0799505d2b9d81b750aeb"
+# host should be preserved but for now the REGISTRY env must be given to change where we look up digest
+image10: "builds-registry.ystack.svc.cluster.local/yolean/toil:ac196cb3f08b15d2b8c6731533f9ab29a8629389@sha256:3c52b5ddac2c1da52eced6f727e530cef18ea9bd6ae0799505d2b9d81b750aeb"

--- a/bin/spec/image-bump_spec.sh
+++ b/bin/spec/image-bump_spec.sh
@@ -1,0 +1,44 @@
+Describe 'y-image-bump'
+  It 'has a help subcommand'
+    When run command y-image-bump help
+    The output should include "BUMP_INCLUDE='--include="
+  End
+
+  tmp=$(mktemp -d)
+
+  It 'runs the image-bump-example folder recursively'
+    cp -r ./spec/image-bump-example/* $tmp/
+    y-image-bump yolean/toil e0c572a0643fb7bfee9eb9775870cc412911319c $tmp
+
+    When run command diff -u ./spec/image-bump-example/variations.yaml $tmp/variations.yaml
+    The status should eq 1
+    The output should include '
+-image1: "yolean/toil:2804b31514bdf162fa3ac527cdb5b1b1cfd4d986"
+-image2: yolean/toil:2804b31514bdf162fa3ac527cdb5b1b1cfd4d986
++image1: "yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d"
++image2: yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+ # not git ref tagged, should be skipped
+ image3: "yolean/toil"
+ image4: yolean/toil
+ image5: yolean/toil:123
+ # should get a new tag+sha
+-image6: yolean/toil:0000000000000000000000000000000000000000@sha256:0000000000000000000000000000000000000000000000000000000000000000
++image6: yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+ # when other URLs change in this particular file we update instances of the same sha256 as well, see also preserve-sha256.yaml
+-image7: yolean/toil:0000000000000000000000000000000000000000@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
++image7: yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+ # correct already, should not change
+ image8: yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+ # with host
+-image9: "docker.io/yolean/toil:ac196cb3f08b15d2b8c6731533f9ab29a8629389@sha256:3c52b5ddac2c1da52eced6f727e530cef18ea9bd6ae0799505d2b9d81b750aeb"
++image9: "docker.io/yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d"
+ # host should be preserved but for now the REGISTRY env must be given to change where we look up digest
+-image10: "builds-registry.ystack.svc.cluster.local/yolean/toil:ac196cb3f08b15d2b8c6731533f9ab29a8629389@sha256:3c52b5ddac2c1da52eced6f727e530cef18ea9bd6ae0799505d2b9d81b750aeb"
++image10: "builds-registry.ystack.svc.cluster.local/yolean/toil:e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d"'
+  End
+
+  It 'preserved tags that had the same digest'
+    When run command diff -s -u ./spec/image-bump-example/preserve-sha256.yaml $tmp/preserve-sha256.yaml
+    The output should include "are identical"
+  End
+End

--- a/bin/spec/spec_helper.sh
+++ b/bin/spec/spec_helper.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=sh
+
+# Defining variables and functions here will affect all specfiles.
+# Change shell options inside a function may cause different behavior,
+# so it is better to set them here.
+# set -eu
+
+# This callback function will be invoked only once before loading specfiles.
+spec_helper_precheck() {
+  # Available functions: info, warn, error, abort, setenv, unsetenv
+  # Available variables: VERSION, SHELL_TYPE, SHELL_VERSION
+  : minimum_version "0.28.1"
+}
+
+# This callback function will be invoked after a specfile has been loaded.
+spec_helper_loaded() {
+  :
+}
+
+# This callback function will be invoked after core modules has been loaded.
+spec_helper_configure() {
+  # Available functions: import, before_each, after_each, before_all, after_all
+  : import 'support/custom_matcher'
+}

--- a/bin/spec/y-image-bump_spec.sh
+++ b/bin/spec/y-image-bump_spec.sh
@@ -41,4 +41,30 @@ Describe 'y-image-bump'
     When run command diff -s -u ./spec/image-bump-example/preserve-sha256.yaml $tmp/preserve-sha256.yaml
     The output should include "are identical"
   End
+
+  It 'updates the images section of a Kustomize yaml, and here the format of existing tags is ignored'
+    When run command diff -u ./spec/image-bump-example/kustomize/kustomization.yaml $tmp/kustomize/kustomization.yaml
+    The status should eq 1
+    The output should include '
+ images:
+   - name: yolean/toil
+-    newTag: latest@sha256:0000000000000000000000000000000000000000000000000000000000000000
++    newTag: e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+   - name: yolean/toil
+-    newTag: a000000000000000000000000000000000000000
++    newTag: e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+   - name: yolean/toil
+-    newTag: 0000000000000000000000000000000000000000@sha256:0000000000000000000000000000000000000000000000000000000000000000
++    newTag: e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+   - name: docker.io/yolean/toil
+     newName: builds-registry.ystack.svc.cluster.local/yolean/toil
+-    newTag: 0000000000000000000000000000000000000000@sha256:0000000000000000000000000000000000000000000000000000000000000000
++    newTag: e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d
+   # for now we ignore if newName might not match the image arg
+   - name: yolean/toil
+     newName: yolean/not-toil
+-    newTag: 0000000000000000000000000000000000000000@sha256:0000000000000000000000000000000000000000000000000000000000000000
++    newTag: e0c572a0643fb7bfee9eb9775870cc412911319c@sha256:700eaa5dcdf8ef01a43150f4d9aa970590f326c3834b7035a56d955a6705f32d'
+  End
+
 End

--- a/bin/y-bin-dependency-download
+++ b/bin/y-bin-dependency-download
@@ -5,6 +5,9 @@ YBIN="$(dirname $0)"
 
 SHA256SUM="sha256sum"
 
+[ -n "$bin_tar_path" ] || bin_tar_path=$bin_tgz_path
+[ -n "$bin_tar_compression" ] || bin_tar_compression=z
+
 platform="$(uname -s)"
 case "$platform" in
   Darwin )
@@ -15,11 +18,11 @@ case "$platform" in
   Linux )
     url=$Linux_url
     sha256=$Linux_sha256
-    case "$bin_tgz_path" in
+    case "$bin_tar_path" in
       */*/*) ;;
       */*)
         set -o noglob
-        bin_tgz_path="--wildcards */$(basename $bin_tgz_path)"
+        bin_tar_path="--wildcards */$(basename $bin_tar_path)"
         ;;
       *) ;;
     esac
@@ -41,9 +44,9 @@ bin_link=$YBIN/$bin_name
   echo "Missing $bin_name binary. Downloading a known version from $url ..." 1>&2
   curl -o $bin_file -L -f $url
   if ! echo "$sha256  $bin_file" | $SHA256SUM -c - 1>&2; then rm $bin_file && exit 1; fi
-  if [ ! -z "$bin_tgz_path" ]; then
-    tar -xvzf $bin_file --strip-components=$(echo $bin_tgz_path | awk -F'/' '{print NF-1}') $bin_tgz_path
-    mv $(basename " $bin_tgz_path") $bin_file
+  if [ ! -z "$bin_tar_path" ]; then
+    tar -xv${bin_tar_compression}f $bin_file --strip-components=$(echo $bin_tar_path | awk -F'/' '{print NF-1}') $bin_tar_path
+    mv $(basename " $bin_tar_path") $bin_file
   fi
   if [ ! -z "$bin_zip_path" ]; then
     tmp=$(mktemp -d)

--- a/bin/y-image-bump
+++ b/bin/y-image-bump
@@ -4,7 +4,7 @@ set -eo pipefail
 
 [ -z "$BUMP_INCLUDE" ] && BUMP_INCLUDE='--include=*.yaml'
 
-[ "$1" = "help" ] && echo "
+[ "$1" = "help" ] && echo "adsf
 Replaces image URLs with other image URLs, for git ref tags.
 Skips ref changes that do not affect image sha, i.e. cached or deterministic builds.
 BUMP_INCLUDE='$BUMP_INCLUDE'
@@ -58,13 +58,11 @@ function imagebump_text {
   shas=$(echo "$diff" | sed 's|^[-\+].*\(@sha256:[0123456789abcdef]\{64\}\).*$|\1|;t;d')
   if [ $(echo "$shas" | sort | uniq | wc -l) -eq 1 ]; then
     echo "Skipped $FILE; only one distinct @sha256 in diff"
-    echo "$diff"
   else
     cp $tmp $FILE
     echo "Bumped $FILE"
   fi
 }
-
 
 function imagebump {
   FILE=$1

--- a/bin/y-image-bump
+++ b/bin/y-image-bump
@@ -2,10 +2,13 @@
 [ -z "$DEBUG" ] || set -x
 set -eo pipefail
 
-[ "$1" = "help" ] && echo '
+[ -z "$BUMP_INCLUDE" ] && BUMP_INCLUDE='--include=*.yaml'
+
+[ "$1" = "help" ] && echo "
 Replaces image URLs with other image URLs, for git ref tags.
 Skips ref changes that do not affect image sha, i.e. cached or deterministic builds.
-' && exit 0
+BUMP_INCLUDE='$BUMP_INCLUDE'
+" && exit 0
 
 IMAGE=$1
 [ -z "$IMAGE" ] && echo "First arg must be a an image like yolean/node-kafka" && exit 1
@@ -15,8 +18,6 @@ TAG=$2
 
 SRC=$3
 [ -z "$SRC" ] && echo "Third arg must be a path like . or /my/hack.js" && exit 1
-
-[ -z "$INCLUDE" ] && INCLUDE='--include=*.yaml'
 
 [ -z "$REGISTRY" ] && REGISTRY="docker.io"
 
@@ -40,9 +41,14 @@ echo "Got $DIGEST for $IMAGE_URL"
 
 tmp=$(mktemp)
 
-function imagebump {
+function imagebump_kustomize {
   FILE=$1
-  [ -z "$FILE" ] && echo "bump requires a file path" && exit 1
+  # newName is currently ignored, if we add support it must take preference over .name
+  yq -i eval ".images.[] |= select(.name == \"*$IMAGE\" and .newTag != \"*$DIGEST\") |= .newTag = \"$TAG@$DIGEST\"" $FILE
+}
+
+function imagebump_text {
+  FILE=$1
   sed "s|\b\($IMAGE:\)\([0123456789abcdef]\{40\}\)\(@sha256:[0123456789abcdef]\{64\}\)\?\b|\1$TAG@$DIGEST|" $FILE > $tmp
   diff=$(diff -u --horizon-lines=0 $FILE $tmp || true)
   if [ -z "$diff" ]; then
@@ -59,8 +65,18 @@ function imagebump {
   fi
 }
 
-[ -f "$SRC" ] && bump $SRC && exit 0
 
-for F in $(grep -lr $INCLUDE "$IMAGE" "$SRC"); do
+function imagebump {
+  FILE=$1
+  [ -z "$FILE" ] && echo "bump requires a file path" && exit 1
+  case $FILE in
+    */kustomization.yaml) imagebump_kustomize $FILE ;;
+    *) imagebump_text $FILE ;;
+  esac
+}
+
+[ -f "$SRC" ] && imagebump $SRC && exit 0
+
+for F in $(grep -lr $BUMP_INCLUDE "$IMAGE" "$SRC"); do
   imagebump $F
 done

--- a/bin/y-k3s-install
+++ b/bin/y-k3s-install
@@ -2,7 +2,7 @@
 [ -z "$DEBUG" ] || set -x
 set -eo pipefail
 
-[ $(id -u) -ne 0 ] && echo "su privileges required for the k3s installer" && exec sudo -E $0 $@
+[ $(id -u) -ne 0 ] && echo "su privileges required for the k3s installer" && exec sudo -E $0 "$@"
 
 export INSTALL_K3S_SKIP_START=true
 export K3S_NODE_NAME=ystack-master

--- a/bin/y-kubefwd
+++ b/bin/y-kubefwd
@@ -23,7 +23,7 @@ bin_name=kubefwd \
   $YBIN/y-bin-dependency-download || exit $?
 
 [ $(id -u) -eq 0 ] || kubectl $ctx cluster-info >/dev/null
-[ $(id -u) -ne 0 ] && echo "su privileges required for kubefwd" && exec sudo -E $0 $ctx $@
+[ $(id -u) -ne 0 ] && echo "su privileges required for kubefwd" && exec sudo -E $0 $ctx "$@"
 
 addargs="$ctx"
 [[ "$*" == *-l* ]] || addargs="$addargs -l ystack-kubefwd!=never"

--- a/bin/y-localhost
+++ b/bin/y-localhost
@@ -23,7 +23,7 @@ case "$platform" in
   Darwin)
     ifconfig lo0 | grep $ip > /dev/null && exit 0
     echo "Loopback alias for $ip $hostname not found. Will try to create ..."
-    [ $(id -u) -eq 0 ] || exec sudo -E $0 $@
+    [ $(id -u) -eq 0 ] || exec sudo -E $0 "$@"
     ifconfig lo0 alias $ip up
     ;;
   Linux)

--- a/bin/y-shellcheck
+++ b/bin/y-shellcheck
@@ -1,0 +1,18 @@
+#!/bin/sh
+[ -z "$DEBUG" ] || set -x
+set -e
+YBIN="$(dirname $0)"
+
+version=0.7.2
+
+bin_name=shellcheck \
+  bin_version=v${version} \
+  Darwin_url=https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-v0.7.2.darwin.x86_64.tar.xz \
+  Darwin_sha256=bafd3eaa4857b675adb96697238c6f66f24957ad33de15537dd16cce011bed5e \
+  Linux_url=https://github.com/koalaman/shellcheck/releases/download/v0.7.2/shellcheck-v0.7.2.linux.x86_64.tar.xz \
+  Linux_sha256=70423609f27b504d6c0c47e340f33652aea975e45f312324f2dbf91c95a3b188 \
+  bin_tar_compression=J \
+  bin_tar_path=shellcheck-v${version}/shellcheck \
+  y-bin-dependency-download 1>&2 || exit $?
+
+y-shellcheck-v${version}-bin "$@" || exit $?

--- a/bin/y-shellspec
+++ b/bin/y-shellspec
@@ -7,7 +7,7 @@ version=0.28.1
 dist_sha256=350d3de04ba61505c54eda31a3c2ee912700f1758b1a80a284bc08fd8b6c5992
 bin=y-shellspec-v${version}-bin
 
-[ -f $YBIN/$bin ] && exec $YBIN/$bin $@ && exit $?
+[ -f $YBIN/$bin ] && exec $YBIN/$bin "$@" && exit $?
 
 [ -e $YBIN/$bin-dist ] && echo "Dist exists without bin symlink, please remove: $YBIN/$bin-dist*" && exit 1
 
@@ -19,4 +19,4 @@ mkdir $YBIN/$bin-dist
 (cd $YBIN/$bin-dist; tar xzf $tmp --strip-components=1)
 (cd $YBIN; ln -s $bin-dist/shellspec $bin; [ -L shellspec ] && rm shellspec; ln -s $bin-dist/shellspec shellspec)
 
-exec $YBIN/$bin $@ && exit $?
+exec $YBIN/$bin "$@" && exit $?

--- a/bin/y-shellspec
+++ b/bin/y-shellspec
@@ -5,7 +5,7 @@ YBIN="$(dirname $0)"
 
 version=0.28.1
 dist_sha256=350d3de04ba61505c54eda31a3c2ee912700f1758b1a80a284bc08fd8b6c5992
-bin=y-shellspec-v${version}
+bin=y-shellspec-v${version}-bin
 
 [ -f $YBIN/$bin ] && exec $YBIN/$bin $@ && exit $?
 

--- a/bin/y-shellspec
+++ b/bin/y-shellspec
@@ -1,0 +1,22 @@
+#!/bin/sh
+[ -z "$DEBUG" ] || set -x
+set -e
+YBIN="$(dirname $0)"
+
+version=0.28.1
+dist_sha256=350d3de04ba61505c54eda31a3c2ee912700f1758b1a80a284bc08fd8b6c5992
+bin=y-shellspec-v${version}
+
+[ -f $YBIN/$bin ] && exec $YBIN/$bin $@ && exit $?
+
+[ -e $YBIN/$bin-dist ] && echo "Dist exists without bin symlink, please remove: $YBIN/$bin-dist*" && exit 1
+
+tmp=$(mktemp)
+curl -o $tmp -L -f https://github.com/shellspec/shellspec/releases/download/${version}/shellspec-dist.tar.gz -s
+if ! echo "$dist_sha256  $tmp" | sha256sum -c - 1>/dev/null; then rm $bin_file && exit 1; fi
+
+mkdir $YBIN/$bin-dist
+(cd $YBIN/$bin-dist; tar xzf $tmp --strip-components=1)
+(cd $YBIN; ln -s $bin-dist/shellspec $bin; [ -L shellspec ] && rm shellspec; ln -s $bin-dist/shellspec shellspec)
+
+exec $YBIN/$bin $@ && exit $?

--- a/bin/y-ubuntu-swapoff
+++ b/bin/y-ubuntu-swapoff
@@ -2,7 +2,7 @@
 [ -z "$DEBUG" ] || set -x
 set -eo pipefail
 
-[ $(id -u) -eq 0 ] || exec sudo $0 $@
+[ $(id -u) -eq 0 ] || exec sudo $0 "$@"
 
 swapoff -a
 # requires reboot, according to https://askubuntu.com/questions/259739/kswapd0-is-taking-a-lot-of-cpu

--- a/test.sh
+++ b/test.sh
@@ -11,6 +11,19 @@ if [[ ! -z "$GIT_COMMIT" ]]; then
   fi
 fi
 
+# CI
+
+# we should raise the bar here as soon as possible
+DEFAULT_SHELLCHECK_LEVEL=error
+[ -n "$SHELLCHECK_LEVEL" ] || SHELLCHECK_LEVEL=$DEFAULT_SHELLCHECK_LEVEL
+echo "Running lint for level \"$SHELLCHECK_LEVEL\" ..."
+y-shellcheck --severity=$SHELLCHECK_LEVEL $(git ls-tree -r HEAD --name-only -- ./bin/ | xargs awk '
+  /^#!.*sh/{print FILENAME}
+  {nextfile}')
+
+echo "Running bin specs ..."
+(cd bin && y-shellspec)
+
 # What we think Docker Hub is running
 set +e
 BULID_EXIT_CODE_ON_NO_CLUSTER=1 GIT_COMMIT=$GIT_COMMIT docker-compose -f docker-compose.test.yml up --build --exit-code-from sut --scale node=1 sut


### PR DESCRIPTION
Should have been in place long time ago, but the trigger now was the new `y-image-bump` that replaces manual work with keeping our yaml up to date. Mistakes there have cost and stability implications in production, unlike much of y-stack's other tooling that is only for dev.

Evaluating https://github.com/koalaman/shellcheck and https://github.com/shellspec/shellspec, both of them a positive experience so far.