### PR TITLE
Reproducible builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ if [[ ! -z "$YSTACK_GIT_COMMIT" ]]; then
     YSTACK_GIT_COMMIT="$YSTACK_GIT_COMMIT-dirty"
   fi
 fi
+docker buildx create --use --driver-opt image=moby/buildkit:v0.13.0
 SOURCE_DATE_EPOCH=0 docker buildx build --progress=plain --platform=linux/amd64,linux/arm64/v8 --output type=image,name=yolean/ystack-runner:$YSTACK_GIT_COMMIT,rewrite-timestamp=true,push=false -f runner.Dockerfile .
 ```
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ if [[ ! -z "$YSTACK_GIT_COMMIT" ]]; then
     YSTACK_GIT_COMMIT="$YSTACK_GIT_COMMIT-dirty"
   fi
 fi
-docker buildx build --progress=plain --platform=linux/amd64,linux/arm64/v8 -t yolean/ystack-runner:$YSTACK_GIT_COMMIT -f runner.Dockerfile .
+SOURCE_DATE_EPOCH=0 docker buildx build --progress=plain --platform=linux/amd64,linux/arm64/v8 --output type=image,name=yolean/ystack-runner:$YSTACK_GIT_COMMIT,rewrite-timestamp=true,push=false -f runner.Dockerfile .
 ```
 
 Dogfooding build

--- a/bin/y-bin.runner.yaml
+++ b/bin/y-bin.runner.yaml
@@ -86,14 +86,14 @@ helm:
     path: ${os}-${arch}/helm
 
 buildctl:
-  version: 0.12.4
+  version: 0.13.0
   templates:
     download: https://github.com/moby/buildkit/releases/download/v${version}/buildkit-v${version}.${os}-${arch}.tar.gz
   sha256:
-    darwin_amd64: 57d5d4e6075842dac8bf6cc86a792242678a16860172a2da91a7fcb8aad93d7a
-    darwin_arm64: 3c3c36dcb07063fef1c8b52faeb22bfd28f9f5dd1cf141b56d18073f8127de77
-    linux_amd64: 75ffe406e4284b77af35447d829767cfa935eb7dd2ea2e3407223d6885bd8ebd
-    linux_arm64: 9166eeaff11721122b9398d6385c7b73d6e4df86797e537c16ac6b6d05eab899
+    darwin_amd64: 812c7dd4a9f790b22ccfe61ad01458d4fd798faf4cf067882bc1c6705224d568
+    darwin_arm64: 64b540d37e49c5990f3d66de6178a4daa2a79e7d4abcae5a69d7b338ca2b42b1
+    linux_amd64: 0893f55180c3da895ad998af25305f32413676a72a36b4372607ff7396f607e8
+    linux_arm64: 265f9756102de5fe3b8f299b7e96a9ef4ff69763805642676129c2713477071d
   archive:
     tool: tar
     #path: $(test 'linux' = $os && echo "bin/buildctl" || echo "buildctl")

--- a/bin/y-build
+++ b/bin/y-build
@@ -116,7 +116,9 @@ case "$IMAGE" in
   * ) echo "Output is restricted to PUSH_REGISTRY=$PUSH_REGISTRY. Got: $IMAGE" && exit 1 ;;
 esac
 
-OUTPUT="type=image,name=$IMAGE,push=true"
+[ -n "$SOURCE_DATE_EPOCH" ] || SOURCE_DATE_EPOCH=0
+
+OUTPUT="type=image,name=$IMAGE,push=true,rewrite-timestamp=true"
 
 BUILD_TAG="$(echo $IMAGE | awk -F/ '{print $NF}' | awk -F@ '{print $1}' | awk -F: '{print $2}')"
 
@@ -141,7 +143,7 @@ OPT_PLATFORM=""
 
 echo "Build command:"
 set -x
-y-buildctl \
+SOURCE_DATE_EPOCH="$SOURCE_DATE_EPOCH" y-buildctl \
   --addr $BUILDKIT_HOST \
   build \
     --frontend dockerfile.v0 \

--- a/buildkit/kustomization.yaml
+++ b/buildkit/kustomization.yaml
@@ -4,7 +4,7 @@ kind: Kustomization
 images:
 - name: moby/buildkit:rootless
   newName: docker.io/moby/buildkit
-  newTag: v0.12.4-rootless@sha256:90095c7852a746c3f35d8cee504e053fdc6a1daf1faa382dcc7ecd830337343a
+  newTag: v0.13.0-rootless@sha256:4d6916c965b817a685ac9b19aa3fe8e91cec9d78eefea70e30f52e9cc514367c
 
 resources:
 - service.yaml

--- a/runner.Dockerfile
+++ b/runner.Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1.4
+# syntax=docker.io/docker/dockerfile:1.7
 FROM --platform=$TARGETPLATFORM ubuntu:22.04@sha256:f9d633ff6640178c2d0525017174a688e2c1aef28f0a0130b26bd5554491f0da \
   as base
 


### PR DESCRIPTION
Note `rewriting layers with source-date-epoch 0 (1970-01-01 00:00:00 +0000 UTC)` in `y-build` output. See e5fd403e2fb8903cc9d5c15083eac4f032278286 for the rationale behind this aggressive choice of date.