### PR TITLE
Restore y-kubeconfig-import

### DIFF
--- a/Y_SCRIPT_AUTHORING.md
+++ b/Y_SCRIPT_AUTHORING.md
@@ -39,7 +39,7 @@ esac
 
 ```bash
 #!/usr/bin/env bash
-[ -z "$DEBUG" ] || set -x
+[ -z "${DEBUG:-}" ] || set -x
 set -eo pipefail
 
 YHELP='y-example - Bump image tags in kustomization files
@@ -123,7 +123,7 @@ if (process.argv[2] === 'help' || process.argv[2] === '--help') {
 |-------|-------------|-------|---------|-------------|
 | Shebang | FAIL | `#!/usr/bin/env bash` or `#!/bin/sh` | `#!/usr/bin/env node` or `*-strip-types` | First line |
 | `set -eo pipefail` | FAIL | Required | n/a | Second or third line |
-| DEBUG pattern | WARN | `[ -z "$DEBUG" ] \|\| set -x` | n/a | Second line |
+| DEBUG pattern | WARN | `[ -z "${DEBUG:-}" ] \|\| set -x` (bare `$DEBUG` also tolerated) | n/a | Second line |
 | Help handler | WARN | `"$1" = "help"` in case/if | `process.argv` includes `help` | See templates above |
 | No `npx` | FAIL | Not in non-comment lines | Not in non-comment lines | Use project deps |
 | No `eval` | FAIL | Not in non-comment lines | No `eval(` calls | Avoid eval |
@@ -212,7 +212,7 @@ Every shell script must start with a shebang and standard preamble:
 
 ```bash
 #!/usr/bin/env bash
-[ -z "$DEBUG" ] || set -x
+[ -z "${DEBUG:-}" ] || set -x
 set -eo pipefail
 ```
 
@@ -295,7 +295,7 @@ Validate required arguments early with clear error messages:
 
 - Document all env vars in help text
 - Provide sensible defaults: `[ -z "$REGISTRY" ] && REGISTRY="docker.io"`
-- Use `DEBUG` for `set -x` tracing (convention: `[ -z "$DEBUG" ] || set -x`)
+- Use `DEBUG` for `set -x` tracing (convention: `[ -z "${DEBUG:-}" ] || set -x`; the guard keeps it safe under `set -u`)
 - Never require secrets as positional args; use env vars or files
 
 ## Shell Practices

--- a/bin/y-kubeconfig-import
+++ b/bin/y-kubeconfig-import
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+[ -z "$DEBUG" ] || set -x
+set -eo pipefail
+
+[ -z "$1" ] && echo "First arg should be the path to a _temporary_ kubeconfig file" && exit 1
+
+CONFTEMP="$1"
+
+[ ! -f "$CONFTEMP" ] && echo "Temporary file $CONFTEMP not found. No import performed." && exit 1
+
+[ -z "$KUBECONFIG" ] && echo "This script requires a KUBECONFIG env. Aborting merge." && exit 1
+
+if [ -f "$KUBECONFIG" ]; then
+  echo "Target kubeconfig $KUBECONFIG already exists. Merging."
+  KUBECONFIG="$CONFTEMP:$KUBECONFIG" kubectl config view --flatten > "$CONFTEMP-merged"
+  mv "$CONFTEMP-merged" "$CONFTEMP"
+else
+  echo "Target kubeconfig $KUBECONFIG doesn't exist. Importing temp as is."
+fi
+mv "$CONFTEMP" "$KUBECONFIG"

--- a/bin/y-kubeconfig-import
+++ b/bin/y-kubeconfig-import
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
-[ -z "$DEBUG" ] || set -x
-set -eo pipefail
+[ -z "${DEBUG:-}" ] || set -x
+set -euo pipefail
 
-[ -z "$1" ] && echo "First arg should be the path to a _temporary_ kubeconfig file" && exit 1
+[ -z "${1:-}" ] && echo "First arg should be the path to a _temporary_ kubeconfig file" && exit 1
 
 CONFTEMP="$1"
 
 [ ! -f "$CONFTEMP" ] && echo "Temporary file $CONFTEMP not found. No import performed." && exit 1
 
-[ -z "$KUBECONFIG" ] && echo "This script requires a KUBECONFIG env. Aborting merge." && exit 1
+[ -z "${KUBECONFIG:-}" ] && echo "This script requires a KUBECONFIG env. Aborting merge." && exit 1
 
 if [ -f "$KUBECONFIG" ]; then
   echo "Target kubeconfig $KUBECONFIG already exists. Merging."
+  # note: current-context becomes whatever CONFTEMP set, because CONFTEMP is listed
+  # first in KUBECONFIG and --flatten preserves the merged current-context.
   KUBECONFIG="$CONFTEMP:$KUBECONFIG" kubectl config view --flatten > "$CONFTEMP-merged"
   mv "$CONFTEMP-merged" "$CONFTEMP"
 else

--- a/bin/y-script-lint
+++ b/bin/y-script-lint
@@ -141,7 +141,7 @@ is_node() { [ "$1" = "node" ] || [ "$1" = "typescript" ]; }
 # --- Static checks ---
 
 check_header_pipefail() { grep -qE '^set -e(u?o pipefail)?$' "$1" 2>/dev/null; }
-check_header_debug() { grep -qE '^\[ -z "\$DEBUG" \] \|\| set -x' "$1" 2>/dev/null; }
+check_header_debug() { grep -qE '^\[ -z "\$(DEBUG|\{DEBUG:-\})" \] \|\| set -x' "$1" 2>/dev/null; }
 
 check_help_handler() {
   local file="$1" lang="$2"


### PR DESCRIPTION
I'm not sure 9b60ed66593c147685bdb445335a8945e7ffd6c0 (#76) is correct that all cluster tooling has been replaced by y-cluster

Update: It wasn't, and it makes sense that `y-cluster kubeconfig` should not have this kind of tool that is unrelated to provisioning.